### PR TITLE
Fixed Issue #328

### DIFF
--- a/src/lab/exp1/Manual.html
+++ b/src/lab/exp1/Manual.html
@@ -111,7 +111,7 @@ Start the experiment with the default values of length, mass and intial displace
 <p><br><br>
 <!-- <a href="shm.htm" target="_blank">Go to Manual view on Simple Harmonic Oscillator Experiment(Click here)</a><br><br>
 </br></br></br></br> -->
-<a>Manual video on Simple Harmonic Oscillator Experiment is under construction</a><br><br>
+<p>Manual video on Simple Harmonic Oscillator Experiment is under construction</p><br><br>
 </br></br></br></br></p>
 </div>						</div>
 					</div>


### PR DESCRIPTION
Fixed Issue #328 by converting the hyperlink to a paragraph plain text.
This prevents it from misleading the user into believing there is a link to the video.